### PR TITLE
Add explicit usings for CodeEvaluator

### DIFF
--- a/StudentTestingApp/Services/CodeEvaluator.cs
+++ b/StudentTestingApp/Services/CodeEvaluator.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using StudentTestingApp.Models;


### PR DESCRIPTION
## Summary
- add System and other explicit using directives to `CodeEvaluator`

## Testing
- `dotnet build StudentTestingApp/StudentTestingApp.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a66283308327b1c2bbde0a77291a