### PR TITLE
Initialize EF at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The next steps will implement the database models, user interface screens, code 
 1. **Add models** representing users, roles, tasks, test cases and submissions. These classes live in `StudentTestingApp/Models`.
 2. **Create `StudentTestingContext`** derived from `DbContext` to access PostgreSQL. The context exposes `DbSet` properties for all entities and seeds the default roles.
 3. **Update the project file** to reference `Microsoft.EntityFrameworkCore` and `Npgsql.EntityFrameworkCore.PostgreSQL` packages.
-4. **Configure the connection string** when starting the application (for instance in `App.xaml.cs`). Example:
+4. **Configure the connection string** when starting the application. `App.xaml.cs` now creates a `StudentTestingContext` with the connection string and calls `Database.Migrate()` on startup. Example:
    ```csharp
    var builder = new DbContextOptionsBuilder<StudentTestingContext>();
    builder.UseNpgsql("Host=localhost;Database=testing;Username=postgres;Password=secret");

--- a/StudentTestingApp/App.xaml.cs
+++ b/StudentTestingApp/App.xaml.cs
@@ -1,8 +1,23 @@
 using System.Windows;
+using Microsoft.EntityFrameworkCore;
+using StudentTestingApp.Models;
 
 namespace StudentTestingApp
 {
     public partial class App : Application
     {
+        public StudentTestingContext Db { get; private set; } = null!;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var options = new DbContextOptionsBuilder<StudentTestingContext>()
+                .UseNpgsql("Host=localhost;Database=testing;Username=postgres;Password=secret")
+                .Options;
+
+            Db = new StudentTestingContext(options);
+            Db.Database.Migrate();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- configure EF Core in `App.xaml.cs` to use PostgreSQL
- run `Database.Migrate()` when the WPF app starts
- mention this startup initialization in README

## Testing
- `dotnet build StudentTestingApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a87ad0c083278e1eb7c226b3f4e4