### PR TITLE
Align context factory connection string with runtime

### DIFF
--- a/StudentTestingApp/Models/StudentTestingContextFactory.cs
+++ b/StudentTestingApp/Models/StudentTestingContextFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -8,7 +9,9 @@ namespace StudentTestingApp.Models
         public StudentTestingContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<StudentTestingContext>();
-            optionsBuilder.UseNpgsql("Host=localhost;Database=testing;Username=postgres;Password=secret");
+            var conn = Environment.GetEnvironmentVariable("CONNECTION_STRING")
+                ?? "Host=localhost;Database=testing;Username=postgres;Password=secret";
+            optionsBuilder.UseNpgsql(conn);
             return new StudentTestingContext(optionsBuilder.Options);
         }
     }


### PR DESCRIPTION
## Summary
- read `CONNECTION_STRING` in `StudentTestingContextFactory`
- default to the same connection string used by `App.xaml.cs`

## Testing
- `dotnet build StudentTestingApp/StudentTestingApp.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d9e1b528832785583c83fdc1881f