### PR TITLE
Add MaterialDesign theme and create-task toolbar

### DIFF
--- a/StudentTestingApp/App.xaml
+++ b/StudentTestingApp/App.xaml
@@ -4,5 +4,13 @@
              StartupUri="Views/LoginWindow.xaml">
 
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/StudentTestingApp/StudentTestingApp.csproj
+++ b/StudentTestingApp/StudentTestingApp.csproj
@@ -10,5 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
+    <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
   </ItemGroup>
 </Project>

--- a/StudentTestingApp/Views/TaskListWindow.xaml
+++ b/StudentTestingApp/Views/TaskListWindow.xaml
@@ -1,13 +1,19 @@
 <Window x:Class="StudentTestingApp.Views.TaskListWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Style="{StaticResource MaterialDesignWindow}"
         Title="Tasks" Height="300" Width="400">
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <ListBox x:Name="TasksListBox" DisplayMemberPath="Title" MouseDoubleClick="TasksListBox_DoubleClick" />
-        <Button x:Name="CreateTaskButton" Grid.Row="1" Content="New Task" Width="80" HorizontalAlignment="Right" Margin="0,5,0,0" Click="CreateTaskButton_Click" Visibility="Collapsed" />
+
+        <ToolBar Grid.Row="0" materialDesign:ColorZoneAssist.Mode="PrimaryDark">
+            <Button x:Name="CreateTaskButton" Content="Create Task" Click="CreateTaskButton_Click" Visibility="Collapsed" />
+        </ToolBar>
+
+        <ListBox x:Name="TasksListBox" Grid.Row="1" DisplayMemberPath="Title" MouseDoubleClick="TasksListBox_DoubleClick" />
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- style windows using MaterialDesignInXaml
- show a toolbar in TaskListWindow with Create Task button
- load MaterialDesign resources globally

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845dacb20ac8327b89e1571dfbe6989