### PR TITLE
Add MaterialDesign UI elements

### DIFF
--- a/StudentTestingApp/App.xaml
+++ b/StudentTestingApp/App.xaml
@@ -1,12 +1,14 @@
 <Application x:Class="StudentTestingApp.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              StartupUri="Views/LoginWindow.xaml">
 
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />

--- a/StudentTestingApp/Views/CodeEditorWindow.xaml
+++ b/StudentTestingApp/Views/CodeEditorWindow.xaml
@@ -1,15 +1,21 @@
 <Window x:Class="StudentTestingApp.Views.CodeEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Code Editor" Height="400" Width="600">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <TextBlock x:Name="DescriptionBlock" TextWrapping="Wrap" Margin="0,0,0,5" />
-        <TextBox x:Name="CodeTextBox" Grid.Row="1" FontFamily="Consolas" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
-        <Button x:Name="SubmitButton" Grid.Row="2" Content="Submit" Width="80" HorizontalAlignment="Right" Margin="0,5,0,0" Click="SubmitButton_Click" />
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Style="{StaticResource MaterialDesignWindow}"
+        Title="Code Editor" Height="500" Width="700">
+    <Grid Background="{DynamicResource MaterialDesignPaper}">
+        <materialDesign:Card Margin="16" Padding="16">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock x:Name="DescriptionBlock" TextWrapping="Wrap" Margin="0,0,0,8" />
+                <TextBox x:Name="CodeTextBox" Grid.Row="1" FontFamily="Consolas" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+                <Button x:Name="SubmitButton" Grid.Row="2" Content="Submit" HorizontalAlignment="Right" Margin="0,8,0,0" Click="SubmitButton_Click" />
+            </Grid>
+        </materialDesign:Card>
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/LoginWindow.xaml
+++ b/StudentTestingApp/Views/LoginWindow.xaml
@@ -1,24 +1,21 @@
 <Window x:Class="StudentTestingApp.Views.LoginWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Login" Height="200" Width="300">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock Text="Username:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" VerticalAlignment="Center" />
-        <TextBox x:Name="UsernameBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" />
-        <TextBlock Text="Password:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" VerticalAlignment="Center" />
-        <PasswordBox x:Name="PasswordBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button x:Name="LoginButton" Content="Login" Width="80" Margin="0,0,5,0" Click="LoginButton_Click" />
-            <Button x:Name="RegisterButton" Content="Register" Width="80" Click="RegisterButton_Click" />
-        </StackPanel>
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Style="{StaticResource MaterialDesignWindow}"
+        Title="Login" Height="250" Width="320">
+    <Grid Background="{DynamicResource MaterialDesignPaper}">
+        <materialDesign:Card Padding="16" Width="260" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <StackPanel>
+                <TextBox x:Name="UsernameBox" Margin="0,0,0,8"
+                         materialDesign:HintAssist.Hint="Username" />
+                <PasswordBox x:Name="PasswordBox" Margin="0,0,0,16"
+                             materialDesign:HintAssist.Hint="Password" />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button x:Name="LoginButton" Content="Login" Margin="0,0,8,0" Click="LoginButton_Click" />
+                    <Button x:Name="RegisterButton" Content="Register" Click="RegisterButton_Click" />
+                </StackPanel>
+            </StackPanel>
+        </materialDesign:Card>
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/TaskCreationWindow.xaml
+++ b/StudentTestingApp/Views/TaskCreationWindow.xaml
@@ -1,26 +1,23 @@
 <Window x:Class="StudentTestingApp.Views.TaskCreationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Create Task" Height="300" Width="400">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <TextBlock Text="Title" />
-        <TextBox x:Name="TitleBox" Grid.Row="1" Margin="0,5,0,5" />
-        <TextBlock Text="Description" Grid.Row="2" />
-        <TextBox x:Name="DescriptionBox" Grid.Row="3" Height="60" AcceptsReturn="True" Margin="0,5,0,5" />
-        <TextBlock Text="Sample Input" Grid.Row="4" />
-        <StackPanel Grid.Row="5">
-            <TextBox x:Name="InputBox" Margin="0,0,0,5" />
-            <TextBlock Text="Expected Output" />
-            <TextBox x:Name="OutputBox" />
-            <Button x:Name="SaveButton" Content="Save" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0" Click="SaveButton_Click" />
-        </StackPanel>
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Style="{StaticResource MaterialDesignWindow}"
+        Title="Create Task" Height="400" Width="420">
+    <Grid Background="{DynamicResource MaterialDesignPaper}">
+        <materialDesign:Card Margin="16" Padding="16">
+            <StackPanel>
+                <TextBox x:Name="TitleBox" Margin="0,0,0,8"
+                         materialDesign:HintAssist.Hint="Title" />
+                <TextBox x:Name="DescriptionBox" Height="80" Margin="0,0,0,8"
+                         AcceptsReturn="True"
+                         materialDesign:HintAssist.Hint="Description" />
+                <TextBox x:Name="InputBox" Margin="0,0,0,8"
+                         materialDesign:HintAssist.Hint="Sample Input" />
+                <TextBox x:Name="OutputBox" Margin="0,0,0,16"
+                         materialDesign:HintAssist.Hint="Expected Output" />
+                <Button x:Name="SaveButton" Content="Save" HorizontalAlignment="Right" Click="SaveButton_Click" />
+            </StackPanel>
+        </materialDesign:Card>
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/TaskListWindow.xaml
+++ b/StudentTestingApp/Views/TaskListWindow.xaml
@@ -3,17 +3,18 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         Style="{StaticResource MaterialDesignWindow}"
-        Title="Tasks" Height="300" Width="400">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        Title="Tasks" Height="350" Width="450">
+    <Grid Background="{DynamicResource MaterialDesignPaper}">
+        <DockPanel>
+            <ToolBar DockPanel.Dock="Top" materialDesign:ColorZoneAssist.Mode="PrimaryDark">
+                <Button x:Name="ToggleThemeButton" Content="Toggle Theme" Click="ToggleThemeButton_Click" />
+                <Separator />
+                <Button x:Name="CreateTaskButton" Content="Create Task" Click="CreateTaskButton_Click" Visibility="Collapsed" />
+            </ToolBar>
 
-        <ToolBar Grid.Row="0" materialDesign:ColorZoneAssist.Mode="PrimaryDark">
-            <Button x:Name="CreateTaskButton" Content="Create Task" Click="CreateTaskButton_Click" Visibility="Collapsed" />
-        </ToolBar>
-
-        <ListBox x:Name="TasksListBox" Grid.Row="1" DisplayMemberPath="Title" MouseDoubleClick="TasksListBox_DoubleClick" />
+            <materialDesign:Card Margin="16" Padding="8">
+                <ListBox x:Name="TasksListBox" DisplayMemberPath="Title" MouseDoubleClick="TasksListBox_DoubleClick" />
+            </materialDesign:Card>
+        </DockPanel>
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/TaskListWindow.xaml.cs
+++ b/StudentTestingApp/Views/TaskListWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using MaterialDesignThemes.Wpf;
 using StudentTestingApp.Models;
 
 namespace StudentTestingApp.Views
@@ -10,6 +11,7 @@ namespace StudentTestingApp.Views
     {
         private readonly StudentTestingContext _context;
         private readonly User _currentUser;
+        private readonly PaletteHelper _paletteHelper = new PaletteHelper();
 
         public TaskListWindow()
         {
@@ -41,6 +43,20 @@ namespace StudentTestingApp.Views
             {
                 TasksListBox.ItemsSource = _context.ProgrammingTasks.ToList();
             }
+        }
+
+        private void ToggleThemeButton_Click(object sender, RoutedEventArgs e)
+        {
+            ITheme theme = _paletteHelper.GetTheme();
+            if (theme.GetBaseTheme() == BaseTheme.Dark)
+            {
+                theme.SetBaseTheme(Theme.Light);
+            }
+            else
+            {
+                theme.SetBaseTheme(Theme.Dark);
+            }
+            _paletteHelper.SetTheme(theme);
         }
     }
 }


### PR DESCRIPTION
## Summary
- include MaterialDesign resource dictionaries in `App.xaml`
- restyle Login, Task list, Task creation and Code editor windows using MaterialDesign controls
- add theme toggle support to `TaskListWindow`

## Testing
- `dotnet build StudentTestingApp.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845db92bfe08327b3a0aba10687bbe4