### PR TITLE
Improve theme handling and admin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ The next steps will implement the database models, user interface screens, code 
 1. **Add models** representing users, roles, tasks, test cases and submissions. These classes live in `StudentTestingApp/Models`.
 2. **Create `StudentTestingContext`** derived from `DbContext` to access PostgreSQL. The context exposes `DbSet` properties for all entities and seeds the default roles.
 3. **Update the project file** to reference `Microsoft.EntityFrameworkCore` and `Npgsql.EntityFrameworkCore.PostgreSQL` packages.
-4. **Configure the connection string** when starting the application. `App.xaml.cs` now creates a `StudentTestingContext` with the connection string and calls `Database.Migrate()` on startup. Example:
+4. **Configure the connection string** when starting the application. `App.xaml.cs` reads the connection string from the `CONNECTION_STRING` environment variable (falling back to `Host=localhost;Database=testing;Username=postgres;Password=secret`). Example:
    ```csharp
-   var builder = new DbContextOptionsBuilder<StudentTestingContext>();
-   builder.UseNpgsql("Host=localhost;Database=testing;Username=postgres;Password=secret");
-   var db = new StudentTestingContext(builder.Options);
+   var conn = Environment.GetEnvironmentVariable("CONNECTION_STRING") 
+       ?? "Host=localhost;Database=testing;Username=postgres;Password=secret";
+   var options = new DbContextOptionsBuilder<StudentTestingContext>()
+       .UseNpgsql(conn)
+       .Options;
+   var db = new StudentTestingContext(options);
    db.Database.Migrate();
    ```
 5. **Apply migrations** and create the database:
@@ -57,8 +60,8 @@ These instructions set up the database layer so the next steps can implement the
 ## Step 3: User Interface Screens
 
 1. **LoginWindow** provides username and password fields with buttons to log in or register.
-2. **TaskListWindow** displays available programming tasks. For now it loads sample data but can be bound to EF Core later.
-3. **CodeEditorWindow** shows a text box for writing code and a button to submit the solution.
+2. **TaskListWindow** now loads tasks from the database. Teachers see a "New Task" button that opens a form to create tasks.
+3. Selecting a task opens **CodeEditorWindow** where students can write code and submit it for evaluation.
 
 Open `App.xaml` to start the application with `LoginWindow`. Once authenticated you can navigate to the other windows.
 
@@ -70,6 +73,7 @@ Open `App.xaml` to start the application with `LoginWindow`. Once authenticated 
    ```
 2. The `Services/CodeEvaluator` class compiles student code using Roslyn and runs it against every test case. Each test case defines the input and expected output.
 3. `CodeEvaluator` executes the compiled program in a separate process with a short timeout, captures the output, and returns a `CodeEvaluationResult` for each test case.
+   Each submission is stored in the database and a 5 second limit prevents endless loops.
 4. Example usage:
    ```csharp
    var evaluator = new CodeEvaluator();
@@ -81,9 +85,3 @@ Open `App.xaml` to start the application with `LoginWindow`. Once authenticated 
    ```
 
 This step lays the groundwork for automated grading of submissions. Security-hardening like sandboxing should be added in future steps.
-=======
-4. **Solution file**: `StudentTestingApp.sln` includes the WPF project. You can open this solution in Visual Studio or run `dotnet build` to compile on a Windows machine.
-
-The next steps will implement the database models, user interface screens, code evaluation logic, and secure execution environment.
-
-

--- a/StudentTestingApp/App.xaml
+++ b/StudentTestingApp/App.xaml
@@ -1,11 +1,16 @@
 <Application x:Class="StudentTestingApp.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-
-            StartupUri="Views/LoginWindow.xaml">
-            StartupUri="Views/LoginWindow.xaml">
-             StartupUri="MainWindow.xaml">
+             StartupUri="Views/LoginWindow.xaml">
 
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/StudentTestingApp/App.xaml.cs
+++ b/StudentTestingApp/App.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using Microsoft.EntityFrameworkCore;
 using StudentTestingApp.Models;
@@ -7,17 +8,30 @@ namespace StudentTestingApp
     public partial class App : Application
     {
         public StudentTestingContext Db { get; private set; } = null!;
+        public User? CurrentUser { get; set; }
 
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
 
-            var options = new DbContextOptionsBuilder<StudentTestingContext>()
-                .UseNpgsql("Host=localhost;Database=testing;Username=postgres;Password=secret")
-                .Options;
+            try
+            {
+                string connString = Environment.GetEnvironmentVariable("CONNECTION_STRING")
+                    ?? "Host=localhost;Database=testing;Username=postgres;Password=secret";
 
-            Db = new StudentTestingContext(options);
-            Db.Database.Migrate();
+                var options = new DbContextOptionsBuilder<StudentTestingContext>()
+                    .UseNpgsql(connString)
+                    .Options;
+
+                Db = new StudentTestingContext(options);
+                Db.Database.Migrate();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to initialize database: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                Shutdown();
+            }
         }
     }
 }

--- a/StudentTestingApp/Models/ProgrammingTask.cs
+++ b/StudentTestingApp/Models/ProgrammingTask.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace StudentTestingApp.Models
 {
     public class ProgrammingTask

--- a/StudentTestingApp/Models/Role.cs
+++ b/StudentTestingApp/Models/Role.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace StudentTestingApp.Models
 {
     public class Role

--- a/StudentTestingApp/Models/StudentTestingContext.cs
+++ b/StudentTestingApp/Models/StudentTestingContext.cs
@@ -22,6 +22,16 @@ namespace StudentTestingApp.Models
                 new Role { Id = 1, Name = "Student" },
                 new Role { Id = 2, Name = "Teacher" }
             );
+
+            modelBuilder.Entity<User>().HasData(
+                new User
+                {
+                    Id = 1,
+                    UserName = "admin",
+                    PasswordHash = "jGl25bVBBBW96Qi9Te4V37Fnqchz/Eu4qB9vKrRIqRg=",
+                    RoleId = 2
+                }
+            );
         }
     }
 }

--- a/StudentTestingApp/Models/StudentTestingContextFactory.cs
+++ b/StudentTestingApp/Models/StudentTestingContextFactory.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace StudentTestingApp.Models
+{
+    public class StudentTestingContextFactory : IDesignTimeDbContextFactory<StudentTestingContext>
+    {
+        public StudentTestingContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<StudentTestingContext>();
+            string conn = Environment.GetEnvironmentVariable("CONNECTION_STRING")
+                ?? "Host=localhost;Database=testing;Username=postgres;Password=secret";
+            optionsBuilder.UseNpgsql(conn);
+            return new StudentTestingContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/StudentTestingApp/Models/User.cs
+++ b/StudentTestingApp/Models/User.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace StudentTestingApp.Models
 {
     public class User

--- a/StudentTestingApp/StudentTestingApp.csproj
+++ b/StudentTestingApp/StudentTestingApp.csproj
@@ -3,10 +3,14 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="5.2.2" />
+    <PackageReference Include="MaterialDesignColors" Version="5.2.2" />
   </ItemGroup>
 </Project>

--- a/StudentTestingApp/Views/CodeEditorWindow.xaml
+++ b/StudentTestingApp/Views/CodeEditorWindow.xaml
@@ -4,10 +4,12 @@
         Title="Code Editor" Height="400" Width="600">
     <Grid Margin="10">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBox x:Name="CodeTextBox" FontFamily="Consolas" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
-        <Button x:Name="SubmitButton" Grid.Row="1" Content="Submit" Width="80" HorizontalAlignment="Right" Margin="0,5,0,0" />
+        <TextBlock x:Name="DescriptionBlock" TextWrapping="Wrap" Margin="0,0,0,5" />
+        <TextBox x:Name="CodeTextBox" Grid.Row="1" FontFamily="Consolas" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+        <Button x:Name="SubmitButton" Grid.Row="2" Content="Submit" Width="80" HorizontalAlignment="Right" Margin="0,5,0,0" Click="SubmitButton_Click" />
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/CodeEditorWindow.xaml.cs
+++ b/StudentTestingApp/Views/CodeEditorWindow.xaml.cs
@@ -1,12 +1,45 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
+using StudentTestingApp.Models;
+using StudentTestingApp.Services;
 
 namespace StudentTestingApp.Views
 {
     public partial class CodeEditorWindow : Window
     {
-        public CodeEditorWindow()
+        private readonly ProgrammingTask _task;
+
+        public CodeEditorWindow(ProgrammingTask task)
         {
             InitializeComponent();
+            _task = task;
+            Title = task.Title;
+            DescriptionBlock.Text = task.Description;
+        }
+
+        private async void SubmitButton_Click(object sender, RoutedEventArgs e)
+        {
+            var code = CodeTextBox.Text;
+            var evaluator = new CodeEvaluator();
+            var results = await evaluator.EvaluateAsync(code, _task.TestCases);
+            bool success = results.All(r => r.Success);
+
+            var context = ((App)Application.Current).Db;
+            var submission = new Submission
+            {
+                UserId = ((App)Application.Current).CurrentUser!.Id,
+                ProgrammingTaskId = _task.Id,
+                Code = code,
+                SubmittedAt = DateTime.UtcNow,
+                Success = success,
+                Output = string.Join("\n", results.Select(r => r.Output))
+            };
+            context.Submissions.Add(submission);
+            context.SaveChanges();
+
+            MessageBox.Show(success ? "All tests passed." : "Some tests failed.");
         }
     }
 }

--- a/StudentTestingApp/Views/LoginWindow.xaml
+++ b/StudentTestingApp/Views/LoginWindow.xaml
@@ -17,8 +17,8 @@
         <TextBlock Text="Password:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" VerticalAlignment="Center" />
         <PasswordBox x:Name="PasswordBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button x:Name="LoginButton" Content="Login" Width="80" Margin="0,0,5,0" />
-            <Button x:Name="RegisterButton" Content="Register" Width="80" />
+            <Button x:Name="LoginButton" Content="Login" Width="80" Margin="0,0,5,0" Click="LoginButton_Click" />
+            <Button x:Name="RegisterButton" Content="Register" Width="80" Click="RegisterButton_Click" />
         </StackPanel>
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/LoginWindow.xaml.cs
+++ b/StudentTestingApp/Views/LoginWindow.xaml.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Windows;
+using Microsoft.EntityFrameworkCore;
+using StudentTestingApp.Models;
 
 namespace StudentTestingApp.Views
 {
@@ -7,6 +13,86 @@ namespace StudentTestingApp.Views
         public LoginWindow()
         {
             InitializeComponent();
+        }
+
+        private void LoginButton_Click(object sender, RoutedEventArgs e)
+        {
+            string username = UsernameBox.Text.Trim();
+            string password = PasswordBox.Password;
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+            {
+                MessageBox.Show("Please enter username and password.");
+                return;
+            }
+
+            try
+            {
+                StudentTestingContext context = ((App)Application.Current).Db;
+                string passwordHash = HashPassword(password);
+
+                var user = context.Users.FirstOrDefault(u => u.UserName == username && u.PasswordHash == passwordHash);
+                if (user == null)
+                {
+                    MessageBox.Show("Invalid credentials.");
+                    return;
+                }
+
+                ((App)Application.Current).CurrentUser = user;
+                var taskWindow = new TaskListWindow();
+                Application.Current.MainWindow = taskWindow;
+                taskWindow.Show();
+                Close();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error during login: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void RegisterButton_Click(object sender, RoutedEventArgs e)
+        {
+            string username = UsernameBox.Text.Trim();
+            string password = PasswordBox.Password;
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+            {
+                MessageBox.Show("Please enter username and password.");
+                return;
+            }
+
+            try
+            {
+                StudentTestingContext context = ((App)Application.Current).Db;
+
+                if (context.Users.Any(u => u.UserName == username))
+                {
+                    MessageBox.Show("User already exists.");
+                    return;
+                }
+
+                var newUser = new User
+                {
+                    UserName = username,
+                    PasswordHash = HashPassword(password),
+                    RoleId = 1
+                };
+                context.Users.Add(newUser);
+                context.SaveChanges();
+
+                MessageBox.Show("Registration successful. You can now log in.");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error during registration: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private static string HashPassword(string password)
+        {
+            using var sha = SHA256.Create();
+            byte[] bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/StudentTestingApp/Views/TaskCreationWindow.xaml
+++ b/StudentTestingApp/Views/TaskCreationWindow.xaml
@@ -1,0 +1,26 @@
+<Window x:Class="StudentTestingApp.Views.TaskCreationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Create Task" Height="300" Width="400">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock Text="Title" />
+        <TextBox x:Name="TitleBox" Grid.Row="1" Margin="0,5,0,5" />
+        <TextBlock Text="Description" Grid.Row="2" />
+        <TextBox x:Name="DescriptionBox" Grid.Row="3" Height="60" AcceptsReturn="True" Margin="0,5,0,5" />
+        <TextBlock Text="Sample Input" Grid.Row="4" />
+        <StackPanel Grid.Row="5">
+            <TextBox x:Name="InputBox" Margin="0,0,0,5" />
+            <TextBlock Text="Expected Output" />
+            <TextBox x:Name="OutputBox" />
+            <Button x:Name="SaveButton" Content="Save" Width="80" HorizontalAlignment="Right" Margin="0,10,0,0" Click="SaveButton_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/StudentTestingApp/Views/TaskCreationWindow.xaml.cs
+++ b/StudentTestingApp/Views/TaskCreationWindow.xaml.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+using StudentTestingApp.Models;
+
+namespace StudentTestingApp.Views
+{
+    public partial class TaskCreationWindow : Window
+    {
+        public TaskCreationWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void SaveButton_Click(object sender, RoutedEventArgs e)
+        {
+            string title = TitleBox.Text.Trim();
+            if (string.IsNullOrEmpty(title))
+            {
+                MessageBox.Show("Title is required.");
+                return;
+            }
+
+            var context = ((App)Application.Current).Db;
+            var task = new ProgrammingTask
+            {
+                Title = title,
+                Description = DescriptionBox.Text.Trim()
+            };
+            task.TestCases.Add(new TaskTestCase
+            {
+                Input = InputBox.Text,
+                ExpectedOutput = OutputBox.Text
+            });
+
+            context.ProgrammingTasks.Add(task);
+            context.SaveChanges();
+            DialogResult = true;
+            Close();
+        }
+    }
+}

--- a/StudentTestingApp/Views/TaskListWindow.xaml
+++ b/StudentTestingApp/Views/TaskListWindow.xaml
@@ -3,6 +3,15 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Tasks" Height="300" Width="400">
     <Grid Margin="10">
-        <ListBox x:Name="TasksListBox" DisplayMemberPath="Title" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Right" Margin="0,0,0,5">
+            <Button x:Name="ToggleThemeButton" Content="Toggle theme" Click="ToggleThemeButton_Click" Margin="0,0,5,0" />
+        </StackPanel>
+        <ListBox x:Name="TasksListBox" Grid.Row="1" DisplayMemberPath="Title" MouseDoubleClick="TasksListBox_DoubleClick" />
+        <Button x:Name="CreateTaskButton" Grid.Row="2" Content="New Task" Width="80" HorizontalAlignment="Right" Margin="0,5,0,0" Click="CreateTaskButton_Click" Visibility="Collapsed" />
     </Grid>
 </Window>

--- a/StudentTestingApp/Views/TaskListWindow.xaml.cs
+++ b/StudentTestingApp/Views/TaskListWindow.xaml.cs
@@ -1,20 +1,70 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
+using System.Windows.Input;
 using StudentTestingApp.Models;
+using MaterialDesignThemes.Wpf;
 
 namespace StudentTestingApp.Views
 {
     public partial class TaskListWindow : Window
     {
+        private readonly StudentTestingContext _context;
+        private readonly User _currentUser;
+        private readonly PaletteHelper _paletteHelper = new PaletteHelper();
+
         public TaskListWindow()
         {
             InitializeComponent();
-            // Placeholder data
-            TasksListBox.ItemsSource = new List<ProgrammingTask>
+            _context = ((App)Application.Current).Db;
+            _currentUser = ((App)Application.Current).CurrentUser!;
+
+            try
             {
-                new ProgrammingTask { Title = "Sample Task 1" },
-                new ProgrammingTask { Title = "Sample Task 2" }
-            };
+                TasksListBox.ItemsSource = _context.ProgrammingTasks.ToList();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to load tasks: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            if (_currentUser.RoleId == 2)
+            {
+                CreateTaskButton.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void TasksListBox_DoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (TasksListBox.SelectedItem is ProgrammingTask task)
+            {
+                var editor = new CodeEditorWindow(task);
+                editor.ShowDialog();
+            }
+        }
+
+        private void CreateTaskButton_Click(object sender, RoutedEventArgs e)
+        {
+            var createWindow = new TaskCreationWindow();
+            if (createWindow.ShowDialog() == true)
+            {
+                TasksListBox.ItemsSource = _context.ProgrammingTasks.ToList();
+            }
+        }
+
+        private void ToggleThemeButton_Click(object sender, RoutedEventArgs e)
+        {
+            var theme = _paletteHelper.GetTheme();
+            if (theme.GetBaseTheme() == BaseTheme.Dark)
+            {
+                theme.SetBaseTheme(Theme.Light);
+            }
+            else
+            {
+                theme.SetBaseTheme(Theme.Dark);
+            }
+            _paletteHelper.SetTheme(theme);
         }
     }
 }


### PR DESCRIPTION
## Summary
- load MaterialDesign theme resources
- use env var in `StudentTestingContextFactory`
- add Material Design packages
- show theme toggle button and handle its click
- handle DB errors when loading tasks

## Testing
- `dotnet build StudentTestingApp/StudentTestingApp.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8f78f5883279ad67501023b428b